### PR TITLE
docs: specify 'application-default' when authenticating

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -116,7 +116,7 @@ Start by authenticating:
 
 .. code-block:: bash
 
-    $ gcloud auth login
+    $ gcloud auth application-default login
 
 And then simply create a client:
 


### PR DESCRIPTION
Update documentation to specify `application-default`

Fixes #17
