### PR TITLE
fix: project_id need to be updated when Project.project_id is actually a project_number 

### DIFF
--- a/google/cloud/resource_manager/project.py
+++ b/google/cloud/resource_manager/project.py
@@ -84,6 +84,7 @@ class Project(object):
     def set_properties_from_api_repr(self, resource):
         """Update specific properties from its API representation."""
         self.name = resource.get("name")
+        self.project_id = resource.get("projectId")
         self.number = resource["projectNumber"]
         self.labels = resource.get("labels", {})
         self.status = resource["lifecycleState"]


### PR DESCRIPTION
_connection.api_request(method="GET", path=f'/projects/{project_id}')
project_id here could be project number, and if you check Project('{project_id}').exists(), it will be True becasue api accept it.
When that happens, project_id should be updated too.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-resource-manager/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
