### PR TITLE
test: update tests to support latest google-cloud-core

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ version = "0.30.2"
 # 'Development Status :: 4 - Beta'
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 3 - Alpha"
-dependencies = ["google-cloud-core >= 1.1.0, < 2.0dev"]
+dependencies = ["google-cloud-core == 1.4.2rc1"]
 extras = {}
 
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ version = "0.30.2"
 # 'Development Status :: 4 - Beta'
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 3 - Alpha"
-dependencies = ["google-cloud-core == 1.4.2rc1"]
+dependencies = ["google-cloud-core == 1.4.2rc2"]
 extras = {}
 
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ version = "0.30.2"
 # 'Development Status :: 4 - Beta'
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 3 - Alpha"
-dependencies = ["google-cloud-core == 1.4.2rc2"]
+dependencies = ["google-cloud-core >= 1.1.0, < 2.0dev"]
 extras = {}
 
 

--- a/tests/unit/test__http.py
+++ b/tests/unit/test__http.py
@@ -28,15 +28,33 @@ class TestConnection(unittest.TestCase):
         return self._get_target_class()(*args, **kw)
 
     def test_build_api_url_no_extra_query_params(self):
+        from six.moves.urllib.parse import parse_qsl
+        from six.moves.urllib.parse import urlsplit
+
         conn = self._make_one(object())
-        URI = "/".join([conn.DEFAULT_API_ENDPOINT, conn.API_VERSION, "foo"])
-        self.assertEqual(conn.build_api_url("/foo"), URI)
+        uri = conn.build_api_url("/foo")
+        scheme, netloc, path, qs, _ = urlsplit(uri)
+        self.assertEqual("%s://%s" % (scheme, netloc), conn.API_BASE_URL)
+        self.assertEqual(path, "/".join(["", conn.API_VERSION, "foo"]))
+        parms = dict(parse_qsl(qs))
+        pretty_print = parms.pop("prettyPrint", "false")
+        self.assertEqual(pretty_print, "false")
+        self.assertEqual(parms, {})
 
     def test_build_api_url_w_custom_endpoint(self):
+        from six.moves.urllib.parse import parse_qsl
+        from six.moves.urllib.parse import urlsplit
+
         custom_endpoint = "https://foo-cloudresourcemanager.googleapis.com"
         conn = self._make_one(object(), api_endpoint=custom_endpoint)
-        URI = "/".join([custom_endpoint, conn.API_VERSION, "foo"])
-        self.assertEqual(conn.build_api_url("/foo"), URI)
+        uri = conn.build_api_url("/foo")
+        scheme, netloc, path, qs, _ = urlsplit(uri)
+        self.assertEqual("%s://%s" % (scheme, netloc), custom_endpoint)
+        self.assertEqual(path, "/".join(["", conn.API_VERSION, "foo"]))
+        parms = dict(parse_qsl(qs))
+        pretty_print = parms.pop("prettyPrint", "false")
+        self.assertEqual(pretty_print, "false")
+        self.assertEqual(parms, {})
 
     def test_build_api_url_w_extra_query_params(self):
         from six.moves.urllib.parse import parse_qsl


### PR DESCRIPTION
`google-cloud-core` version 1.4.2 populates `prettyPrint=false` by
default. Update the connection tests to expect a value for
`prettyPrint`.

This PR also serves to test that the changes in https://github.com/googleapis/python-cloud-core/pull/28 do not break this library.