### PR TITLE
chore: add default_version and codeowner_team to .repo-metadata.json

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -1,14 +1,16 @@
 {
-  "name": "cloudresourcemanager",
-  "name_pretty": "Google Cloud Resource Manager API",
-  "product_documentation": "https://cloud.google.com/resource-manager",
-  "client_documentation": "https://googleapis.dev/python/cloudresourcemanager/latest",
-  "issue_tracker": "https://issuetracker.google.com/savedsearches/559757",
-  "release_level": "ga",
-  "language": "python",
-  "library_type": "GAPIC_MANUAL",
-  "repo": "googleapis/python-resource-manager",
-  "distribution_name": "google-cloud-resource-manager",
-  "api_id": "cloudresourcemanager.googleapis.com",
-  "requires_billing": true
+    "name": "cloudresourcemanager",
+    "name_pretty": "Google Cloud Resource Manager API",
+    "product_documentation": "https://cloud.google.com/resource-manager",
+    "client_documentation": "https://googleapis.dev/python/cloudresourcemanager/latest",
+    "issue_tracker": "https://issuetracker.google.com/savedsearches/559757",
+    "release_level": "ga",
+    "language": "python",
+    "library_type": "GAPIC_MANUAL",
+    "repo": "googleapis/python-resource-manager",
+    "distribution_name": "google-cloud-resource-manager",
+    "api_id": "cloudresourcemanager.googleapis.com",
+    "requires_billing": true,
+    "default_version": "",
+    "codeowner_team": ""
 }

--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -11,6 +11,6 @@
     "distribution_name": "google-cloud-resource-manager",
     "api_id": "cloudresourcemanager.googleapis.com",
     "requires_billing": true,
-    "default_version": "",
+    "default_version": "v3",
     "codeowner_team": ""
 }


### PR DESCRIPTION
By default the code owner will be googleapis/yoshi-python. This change is needed for the following synthtool PRs.

googleapis/synthtool#1201
googleapis/synthtool#1114