### PR TITLE
chore: update doc page from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "cloudresourcemanager",
     "name_pretty": "Google Cloud Resource Manager API",
     "product_documentation": "https://cloud.google.com/resource-manager",
-    "client_documentation": "https://googleapis.dev/python/cloudresourcemanager/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/cloudresourcemanager/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/559757",
     "release_level": "ga",
     "language": "python",


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages.