### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "cloudresourcemanager",
     "name_pretty": "Google Cloud Resource Manager API",
     "product_documentation": "https://cloud.google.com/resource-manager",
-    "client_documentation": "https://googleapis.dev/python/cloudresourcemanager/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/cloudresourcemanager/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/559757",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ With this API, you can do the following:
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-resource-manager.svg
    :target: https://pypi.org/project/google-cloud-resource-manager/
 .. _Google Cloud Resource Manager: https://cloud.google.com/resource-manager
-.. _Client Library Documentation: https://googleapis.dev/python/cloudresourcemanager/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/cloudresourcemanager/latest
 .. _Product Documentation:  https://cloud.google.com/resource-manager
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.