### PR TITLE
chore(deps): allow google-cloud-core v2 on v0 release

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,22 @@
+on:
+  pull_request:
+    branches:
+      - v0
+name: docs
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Setup Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.7"
+    - name: Install nox
+      run: |
+        python -m pip install --upgrade setuptools pip wheel
+        python -m pip install nox
+    - name: Run docs
+      run: |
+        nox -s docs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+on:
+  pull_request:
+    branches:
+      - v0
+name: lint
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Setup Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.7"
+    - name: Install nox
+      run: |
+        python -m pip install --upgrade setuptools pip wheel
+        python -m pip install nox
+    - name: Run lint
+      run: |
+        nox -s lint
+    - name: Run lint_setup_py
+      run: |
+        nox -s lint_setup_py

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -1,0 +1,57 @@
+on:
+  pull_request:
+    branches:
+      - v0
+name: unittest
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: ['3.6', '3.7', '3.8']
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Setup Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python }}
+    - name: Install nox
+      run: |
+        python -m pip install --upgrade setuptools pip wheel
+        python -m pip install nox
+    - name: Run unit tests
+      env:
+        COVERAGE_FILE: .coverage-${{ matrix.python }}
+      run: |
+        nox -s unit-${{ matrix.python }}
+    - name: Upload coverage results
+      uses: actions/upload-artifact@v3
+      with:
+        name: coverage-artifacts
+        path: .coverage-${{ matrix.python }}
+
+  cover:
+    runs-on: ubuntu-latest
+    needs:
+        - unit
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Setup Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.7"
+    - name: Install coverage
+      run: |
+        python -m pip install --upgrade setuptools pip wheel
+        python -m pip install coverage
+    - name: Download coverage results
+      uses: actions/download-artifact@v3
+      with:
+        name: coverage-artifacts
+        path: .coverage-results/
+    - name: Report coverage results
+      run: |
+        coverage combine .coverage-results/.coverage*
+        coverage report --show-missing --fail-under=80

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ version = "0.30.3"
 # 'Development Status :: 4 - Beta'
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 3 - Alpha"
-dependencies = ["google-cloud-core >= 1.1.0, < 2.0dev"]
+dependencies = ["google-cloud-core >= 1.1.0, < 3.0dev"]
 extras = {}
 
 


### PR DESCRIPTION
Allow google-cloud-core<3.0.0dev on previous release of library. Note that this PR is to a new protected branch **v0**, not **main**.

This will be followed by a release PR and is a step towards removing https://github.com/googleapis/google-cloud-python/issues/10566

BEGIN_COMMIT_OVERRIDE
fix(v0): allow google-cloud-core v2

END_COMMIT_OVERRIDE