### PR TITLE
fix: omit tests package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setuptools.setup(
     author_email="googleapis-packages@google.com",
     license="Apache 2.0",
     url=url,
-    packages=setuptools.PEP420PackageFinder.find(),
+    packages=packages,
     namespace_packages=("google", "google.cloud"),
     platforms="Posix; MacOS X; Windows",
     include_package_data=True,


### PR DESCRIPTION
caused by https://github.com/googleapis/python-resource-manager/pull/62/commits/8fa2ec41d6ab4cf4975b2663afcd86fe40256d20

Apoligies if I'm missing something: I'm not entirely sure why the local packages/namespaces are still being generated but then discarded for the actual `setuptools.setup`.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-resource-manager/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #194 🦕
